### PR TITLE
Hotfix HTML entities failure

### DIFF
--- a/jquery.dependent-selects.coffee
+++ b/jquery.dependent-selects.coffee
@@ -218,7 +218,7 @@
         val = $option.val()
         if name.length > 1
           # Create sub select
-          $subSelect = createNewSelect(name[0], $select, depth + 1)
+          $subSelect = createNewSelect(htmlEncode(name[0]), $select, depth + 1)
           # Copy option into sub select
           $newOption = $option.clone()
           $newOption.html($.trim(splitOptionName($newOption)[1..-1].join(options.separator)))
@@ -237,6 +237,9 @@
 
       $select.off('change').on 'change', ->
         selectChange($select)
+
+    htmlEncode = (value) ->
+      $('<div/>').text(value).html();
 
     # Loop through each of the selects the plugin is called on, and set them up!
     @each ->

--- a/jquery.dependent-selects.js
+++ b/jquery.dependent-selects.js
@@ -7,7 +7,7 @@
 
 (function($) {
   return $.fn.dependentSelects = function(options) {
-    var clearAllSelectsByParent, createNewSelect, createSelectId, findSelectParent, hideSelect, insertLabel, insertPlaceholderSelect, labelAtDepth, placeholderOptionAtDepth, placeholderSelectAtDepth, prepareSelect, selectChange, selectPreSelected, selectedOption, showSelect, splitOptionName;
+    var clearAllSelectsByParent, createNewSelect, createSelectId, findSelectParent, hideSelect, htmlEncode, insertLabel, insertPlaceholderSelect, labelAtDepth, placeholderOptionAtDepth, placeholderSelectAtDepth, prepareSelect, selectChange, selectPreSelected, selectedOption, showSelect, splitOptionName;
     if (options == null) {
       options = {};
     }
@@ -249,7 +249,7 @@
         name = splitOptionName($option);
         val = $option.val();
         if (name.length > 1) {
-          $subSelect = createNewSelect(name[0], $select, depth + 1);
+          $subSelect = createNewSelect(htmlEncode(name[0]), $select, depth + 1);
           $newOption = $option.clone();
           $newOption.html($.trim(splitOptionName($newOption).slice(1).join(options.separator)));
           $subSelect.append($newOption);
@@ -265,6 +265,9 @@
       return $select.off('change').on('change', function() {
         return selectChange($select);
       });
+    };
+    htmlEncode = function(value) {
+      return $('<div/>').text(value).html();
     };
     return this.each(function() {
       var $select;


### PR DESCRIPTION
Names are encoded as html entities so the comparison between a value and a data attribute is always the same. Issue: resolve #9